### PR TITLE
Pastel + neon theme refresh, GigaScience citation, and missing suite members

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,7 @@ twitter:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - IMPLEMENTATION_SUMMARY.md
   - node_modules
   - vendor/bundle/
   - vendor/cache/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,37 @@
+<footer class="site-footer h-card">
+  <data class="u-url" href="{{ "/" | relative_url }}"></data>
+
+  <div class="wrapper">
+
+    <h2 class="footer-heading">{{ site.title | escape }}</h2>
+
+    <div class="footer-cols">
+      <div class="footer-col">
+        <p class="footer-name">{{ site.author.name | escape }}</p>
+        <p>{{ site.author.organization | escape }}<br>Berkeley, California, USA</p>
+      </div>
+
+      <div class="footer-col">
+        <p><a href="mailto:{{ site.email }}">{{ site.email }}</a></p>
+        <p><a href="https://github.com/{{ site.github_username }}">github.com/{{ site.github_username }}</a></p>
+        <p><a href="{{ site.author.url }}">LBNL profile</a></p>
+      </div>
+
+      <div class="footer-col">
+        <p>{{ site.description | escape }}</p>
+      </div>
+    </div>
+
+    <p class="footer-family">
+      <span>KG-Microbe Mechs:</span>
+      <a href="{{ "/culturemech/" | relative_url }}">CultureMech</a>
+      <a href="{{ "/mediaingredientmech/" | relative_url }}">MediaIngredientMech</a>
+      <a href="{{ "/communitymech/" | relative_url }}">CommunityMech</a>
+      <a href="https://culturebotai.github.io/TraitMech/">TraitMech</a>
+      <a href="https://culturebotai.github.io/proteintraitsmech/">ProteinTraitsMech</a>
+      <a href="{{ "/microgrowagents/" | relative_url }}">MicroGrowAgents</a>
+    </p>
+
+  </div>
+
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,20 @@
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/custom.css" | relative_url }}">
+  <meta name="theme-color" content="#FFD8B2" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#111613" media="(prefers-color-scheme: dark)">
+
+  <!-- Apply the saved light/dark preference before first paint. -->
+  <script>
+    (function () {
+      try {
+        var saved = localStorage.getItem("culturebot-theme");
+        if (saved === "light" || saved === "dark") {
+          document.documentElement.setAttribute("data-theme", saved);
+        }
+      } catch (e) { /* private mode: fall back to prefers-color-scheme */ }
+    })();
+  </script>
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
@@ -100,13 +114,18 @@
           {"@type": "Person", "name": "Christopher J. Mungall"},
           {"@id": "{{ site.url }}/#marcin"}
         ],
-        "datePublished": "2025-02-24",
+        "datePublished": "2026-07-10",
         "publisher": {
           "@type": "Organization",
-          "name": "bioRxiv"
+          "name": "GigaScience"
         },
-        "url": "https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1",
-        "identifier": "https://doi.org/10.1101/2025.02.24.639989",
+        "isPartOf": {
+          "@type": "Periodical",
+          "name": "GigaScience",
+          "issn": "2047-217X"
+        },
+        "url": "https://doi.org/10.1093/gigascience/giag077",
+        "identifier": "https://doi.org/10.1093/gigascience/giag077",
         "about": "knowledge graph, microbiology, microbiome, AI, machine learning"
       },
       {
@@ -166,7 +185,7 @@
             "name": "How can I access KG-Microbe?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "KG-Microbe is available on GitHub at https://github.com/Knowledge-Graph-Hub/kg-microbe under the BSD-3-Clause license. The preprint is available at https://doi.org/10.1101/2025.02.24.639989"
+              "text": "KG-Microbe is available on GitHub at https://github.com/Knowledge-Graph-Hub/kg-microbe under the BSD-3-Clause license. The publication is available in GigaScience at https://doi.org/10.1093/gigascience/giag077"
             }
           },
           {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,61 @@
 
     {%- include footer.html -%}
 
+    <script>
+      (function () {
+        var root = document.documentElement;
+        var KEY = "culturebot-theme";
+
+        function resolved() {
+          var set = root.getAttribute("data-theme");
+          if (set) { return set; }
+          return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+
+        function label(theme) {
+          return theme === "dark" ? "Switch to light theme" : "Switch to dark theme";
+        }
+
+        // Light/dark toggle, added to the site header.
+        var host = document.querySelector(".site-header .wrapper");
+        if (host) {
+          var btn = document.createElement("button");
+          btn.type = "button";
+          btn.className = "theme-toggle";
+          btn.textContent = resolved() === "dark" ? "☀" : "☾";
+          btn.setAttribute("aria-label", label(resolved()));
+          btn.title = btn.getAttribute("aria-label");
+
+          btn.addEventListener("click", function () {
+            var next = resolved() === "dark" ? "light" : "dark";
+            root.setAttribute("data-theme", next);
+            try { localStorage.setItem(KEY, next); } catch (e) { /* private mode */ }
+            btn.textContent = next === "dark" ? "☀" : "☾";
+            btn.setAttribute("aria-label", label(next));
+            btn.title = btn.getAttribute("aria-label");
+          });
+
+          host.appendChild(btn);
+        }
+
+        // Mark the nav link for the current page — Minima does not do this.
+        var trim = function (p) {
+          p = p.replace(/index\.html$/, "");
+          return p.length > 1 ? p.replace(/\/$/, "") : p;
+        };
+        var here = trim(location.pathname);
+        Array.prototype.forEach.call(
+          document.querySelectorAll(".site-nav .page-link"),
+          function (link) {
+            if (trim(link.pathname) === here) {
+              link.classList.add("current");
+              link.setAttribute("aria-current", "page");
+            }
+          }
+        );
+      })();
+    </script>
+
   </body>
 
 </html>

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1,4 +1,208 @@
-/* Custom overrides for the Minima theme */
+/* ==========================================================================
+   CultureBotAI site theme — pastel + neon overrides for the Minima theme.
+
+   Palette: pastel peach + pastel gray-green (sage), burnt-orange accent,
+   with neon orange/mint used sparingly for glows, rules and hover states.
+   Deliberately distinct from the sibling X-Mech sites, which already use
+   pink/blue (CommunityMech), teal/amber (ProteinTraitsMech), gray/red
+   (TraitMech), aqua/purple (MediaIngredientMech) and green (CultureMech),
+   while keeping the same light, positive visual language: pastel hero
+   gradient, rounded cards, pill buttons and soft shadows.
+   ========================================================================== */
+
+:root {
+  --pastel-a: #FFD8B2;          /* pastel peach   */
+  --pastel-b: #DDE8DF;          /* pastel sage    */
+  --accent:   #C25E12;          /* burnt orange   */
+  --accent-2: #3F7D62;          /* deep sage      */
+  --neon:     #FF7A18;          /* neon orange    */
+  --neon-2:   #2FE0A0;          /* neon mint      */
+  --ink:      #1e2321;
+  --muted:    #5a635e;
+  --card:     #ffffff;
+  --bg:       #F4F8F5;
+  --line:     rgba(0, 0, 0, .10);
+  --wash-a:   #F6EDE4;          /* pastel-a tint, color-mix fallback */
+  --wash-b:   #EDF3EE;          /* pastel-b tint, color-mix fallback */
+  --shadow:   0 1px 3px rgba(30, 45, 38, .07);
+  --shadow-lg: 0 12px 30px rgba(30, 45, 38, .12);
+  --radius:   16px;
+  color-scheme: light;
+}
+
+/* ---- Dark theme: OS preference, overridable by the toggle ---------------- */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --pastel-a: #2f2319;
+    --pastel-b: #141a17;
+    --accent:   #FFA35C;
+    --accent-2: #7FD8AE;
+    --ink:      #e9efea;
+    --muted:    #a0b2a8;
+    --card:     #1a201d;
+    --bg:       #111613;
+    --line:     #2b3531;
+    --wash-a:   #221b16;
+    --wash-b:   #171d1a;
+    --shadow:   0 1px 3px rgba(0, 0, 0, .4);
+    --shadow-lg: 0 12px 30px rgba(0, 0, 0, .5);
+    color-scheme: dark;
+  }
+}
+
+:root[data-theme="dark"] {
+  --pastel-a: #2f2319;
+  --pastel-b: #141a17;
+  --accent:   #FFA35C;
+  --accent-2: #7FD8AE;
+  --ink:      #e9efea;
+  --muted:    #a0b2a8;
+  --card:     #1a201d;
+  --bg:       #111613;
+  --line:     #2b3531;
+  --wash-a:   #221b16;
+  --wash-b:   #171d1a;
+  --shadow:   0 1px 3px rgba(0, 0, 0, .4);
+  --shadow-lg: 0 12px 30px rgba(0, 0, 0, .5);
+  color-scheme: dark;
+}
+
+/* ==========================================================================
+   Base
+   ========================================================================== */
+
+html { scroll-behavior: smooth; }
+
+body {
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(60rem 32rem at 12% -8%, rgba(255, 176, 106, .28), transparent 62%),
+    radial-gradient(52rem 30rem at 92% 2%, rgba(120, 190, 160, .18), transparent 62%);
+  background-attachment: fixed;
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 17px;
+  line-height: 1.62;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrapper {
+  max-width: 1040px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+::selection { background: rgba(255, 122, 24, .25); }
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color .15s ease, background-size .2s ease;
+}
+
+/* Neon underline that grows on hover, for body links only. */
+.page-content a {
+  background-image: linear-gradient(90deg, var(--neon), var(--neon-2));
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  background-size: 0 2px;
+  padding-bottom: 1px;
+}
+
+.page-content a:hover {
+  background-size: 100% 2px;
+  text-decoration: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--neon);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ==========================================================================
+   Header
+   ========================================================================== */
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  min-height: 0;
+  border-top: 0;
+  border-bottom: 1px solid var(--line);
+  background: var(--card);
+  background: rgba(255, 255, 255, .82);
+  -webkit-backdrop-filter: saturate(1.6) blur(10px);
+  backdrop-filter: saturate(1.6) blur(10px);
+}
+
+:root[data-theme="dark"] .site-header { background: rgba(26, 32, 29, .85); }
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .site-header { background: rgba(26, 32, 29, .85); }
+}
+
+/* Neon hairline along the top edge. */
+.site-header::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--neon), var(--pastel-a), var(--neon-2));
+}
+
+.site-title,
+.site-title:visited {
+  font-weight: 800;
+  font-size: 1.4rem;
+  letter-spacing: -.02em;
+  color: var(--accent);
+  background: linear-gradient(100deg, var(--accent), var(--accent-2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.site-nav {
+  background: transparent;
+  border: 0;
+}
+
+.site-nav .page-link,
+.site-nav .page-link:visited {
+  color: var(--muted);
+  font-size: .88rem;
+  font-weight: 600;
+  padding: .3em .72em;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: color .15s ease, background .15s ease, border-color .15s ease, box-shadow .15s ease;
+}
+
+.site-nav .page-link:hover {
+  color: var(--accent);
+  background: var(--wash-a);
+  border-color: var(--line);
+  box-shadow: 0 2px 10px rgba(255, 122, 24, .18);
+  text-decoration: none;
+}
+
+.site-nav .page-link.current {
+  color: #fff;
+  background: linear-gradient(100deg, var(--accent), var(--neon));
+  border-color: transparent;
+  box-shadow: 0 3px 12px rgba(255, 122, 24, .3);
+}
+
+/* The dark-theme accent is light, so flip the pill's label to dark ink. */
+:root[data-theme="dark"] .site-nav .page-link.current { color: #111613; }
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .site-nav .page-link.current { color: #111613; }
+}
 
 /* Header navigation: with many nav links the default float-based header
    overflows the page on wider screens. Use a flex row that wraps instead.
@@ -8,15 +212,15 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-  }
-
-  .site-header {
-    min-height: 0;
+    gap: .25rem .4rem;
+    padding-top: .55rem;
+    padding-bottom: .55rem;
   }
 
   .site-title {
     float: none;
-    margin-right: auto;
+    margin: 0 auto 0 0;
+    line-height: 1.3;
   }
 
   .site-nav {
@@ -26,6 +230,383 @@
 
   .site-nav .page-link {
     display: inline-block;
-    line-height: 2;
+    line-height: 1.9;
+    margin-left: 2px;
   }
+
+  /* Keep the toggle in the top-right corner rather than letting it wrap
+     onto a row of its own once the nav links wrap. */
+  .site-header .wrapper { position: relative; padding-right: 68px; }
+
+  .theme-toggle {
+    position: absolute;
+    top: .5rem;
+    right: 24px;
+    margin-left: 0;
+  }
+}
+
+/* Mobile dropdown menu */
+@media screen and (max-width: 600px) {
+  .site-nav {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    box-shadow: var(--shadow-lg);
+  }
+
+  .site-nav .menu-icon > svg path { fill: var(--accent); }
+
+  .site-nav .page-link {
+    display: block;
+    margin: 2px 0;
+    text-align: right;
+  }
+}
+
+/* ---- Light/dark toggle (injected by _layouts/default.html) --------------- */
+.theme-toggle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin-left: .35rem;
+  padding: 0;
+  font-size: .95rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--ink);
+  background: var(--wash-a);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  transition: transform .15s ease, box-shadow .15s ease;
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(255, 122, 24, .32);
+}
+
+@media screen and (max-width: 600px) {
+  .theme-toggle {
+    position: absolute;
+    top: 13px;
+    right: 68px;
+    z-index: 41;
+  }
+}
+
+/* ==========================================================================
+   Content
+   ========================================================================== */
+
+.page-content { padding: 0 0 3rem; }
+
+/* ---- Hero: first heading of a page plus its lede paragraph --------------- */
+.page-content > .wrapper > h1:first-child,
+.page-content .post-content > h1:first-child,
+.page-content .home > h1:first-child {
+  margin: 2rem 0 2.6rem;
+  padding: 2.4rem 2rem;
+  font-size: 2.35rem;
+  font-weight: 800;
+  letter-spacing: -.025em;
+  line-height: 1.18;
+  color: var(--ink);
+  background: linear-gradient(135deg, var(--pastel-a), var(--pastel-b));
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+/* When a lede paragraph follows the title, merge the two into one card.
+   Guarded so browsers without :has() keep a self-contained title card. */
+@supports selector(:has(+ p)) {
+  .page-content > .wrapper > h1:first-child:has(+ p),
+  .page-content .post-content > h1:first-child:has(+ p),
+  .page-content .home > h1:first-child:has(+ p) {
+    margin-bottom: 0;
+    padding-bottom: 1.5rem;
+    border-bottom: 0;
+    border-radius: var(--radius) var(--radius) 0 0;
+  }
+
+  .page-content > .wrapper > h1:first-child + p,
+  .page-content .post-content > h1:first-child + p,
+  .page-content .home > h1:first-child + p {
+    margin: 0 0 2.6rem;
+    padding: 0 2rem 2.2rem;
+    font-size: 1.06rem;
+    color: var(--ink);
+    background: linear-gradient(135deg, var(--pastel-a), var(--pastel-b));
+    border: 1px solid var(--line);
+    border-top: 0;
+    border-radius: 0 0 var(--radius) var(--radius);
+    box-shadow: var(--shadow);
+  }
+}
+
+/* ---- Headings ----------------------------------------------------------- */
+.page-content h2 {
+  position: relative;
+  margin: 2.6rem 0 1rem;
+  padding-bottom: .4rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -.015em;
+  color: var(--ink);
+}
+
+.page-content h2::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 74px;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--neon), var(--neon-2));
+}
+
+.page-content h3 {
+  margin: 2rem 0 .6rem;
+  padding-left: .75rem;
+  font-size: 1.22rem;
+  font-weight: 700;
+  color: var(--accent);
+  border-left: 3px solid var(--neon);
+  border-image: linear-gradient(180deg, var(--neon), var(--neon-2)) 1;
+}
+
+.page-content h4 {
+  margin: 1.6rem 0 .4rem;
+  font-size: .98rem;
+  font-weight: 700;
+  color: var(--accent-2);
+  text-transform: uppercase;
+  letter-spacing: .06em;
+}
+
+/* ---- Lists -------------------------------------------------------------- */
+.page-content ul { list-style: none; padding-left: 1.35rem; }
+
+.page-content ul > li { position: relative; margin-bottom: .35rem; }
+
+.page-content ul > li::before {
+  content: "";
+  position: absolute;
+  left: -1rem;
+  top: .68em;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--neon), var(--neon-2));
+  box-shadow: 0 0 6px rgba(255, 122, 24, .5);
+}
+
+.page-content ol { padding-left: 1.4rem; }
+
+.page-content ol > li::marker { color: var(--accent); font-weight: 700; }
+
+/* ---- Rules, quotes, tables, code ---------------------------------------- */
+.page-content hr {
+  height: 2px;
+  margin: 2.8rem 0;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, var(--neon), var(--neon-2), transparent);
+  opacity: .55;
+}
+
+blockquote {
+  color: var(--ink);
+  font-style: normal;
+  font-size: 1rem;
+  letter-spacing: 0;
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  box-shadow: var(--shadow);
+}
+
+blockquote > :last-child { margin-bottom: 0; }
+
+table {
+  display: block;
+  overflow-x: auto;
+  width: 100%;
+  margin: 1.5rem 0;
+  color: var(--ink);
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  border-collapse: separate;
+  border-spacing: 0;
+  box-shadow: var(--shadow);
+}
+
+table th {
+  background: var(--wash-a);
+  color: var(--ink);
+  font-weight: 700;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  padding: .7rem .9rem;
+  text-align: left;
+}
+
+table td {
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  padding: .65rem .9rem;
+}
+
+table tr:last-child td { border-bottom: 0; }
+table tr:nth-child(even) td { background: var(--wash-b); }
+
+code {
+  background: var(--wash-b);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--accent);
+  font-size: .88em;
+  padding: .1em .38em;
+}
+
+pre {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1rem 1.15rem;
+}
+
+pre > code {
+  background: transparent;
+  border: 0;
+  color: var(--ink);
+  padding: 0;
+}
+
+/* Minima ships a lavender panel for Rouge blocks; use the site wash instead. */
+.highlight,
+.highlighter-rouge .highlight,
+figure.highlight {
+  background: var(--wash-b);
+  border-radius: var(--radius);
+}
+
+/* Rouge's token palette is tuned for its own lavender panel. Remap the common
+   tokens onto theme variables so code reads correctly in both themes. */
+.highlight,
+.highlight pre { color: var(--ink); }
+.highlight .k, .highlight .kd, .highlight .kn, .highlight .kp,
+.highlight .kr, .highlight .kt, .highlight .nt { color: var(--accent); }
+.highlight .s, .highlight .s1, .highlight .s2, .highlight .sb, .highlight .sc,
+.highlight .sd, .highlight .se, .highlight .sh, .highlight .si, .highlight .sx,
+.highlight .m, .highlight .mi, .highlight .mf { color: var(--accent-2); }
+.highlight .c, .highlight .c1, .highlight .cm, .highlight .cs { color: var(--muted); font-style: italic; }
+.highlight .n, .highlight .na, .highlight .nb, .highlight .nc, .highlight .nf,
+.highlight .nn, .highlight .nv, .highlight .o, .highlight .p { color: var(--ink); }
+
+img { max-width: 100%; border-radius: var(--radius); }
+
+strong { color: var(--ink); font-weight: 700; }
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+
+.site-footer {
+  margin-top: 2rem;
+  padding: 2.2rem 0 2.6rem;
+  border-top: 1px solid var(--line);
+  background: var(--wash-b);
+  color: var(--muted);
+}
+
+.site-footer .footer-heading {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.site-footer a,
+.site-footer a:visited { color: var(--accent); }
+
+.site-footer .contact-list,
+.site-footer .social-media-list { list-style: none; padding-left: 0; }
+
+.site-footer .footer-cols {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1rem 2rem;
+  margin-top: .8rem;
+  font-size: .92rem;
+}
+
+.site-footer .footer-cols p { margin-bottom: .5rem; }
+.site-footer .footer-name { font-weight: 700; color: var(--ink); }
+
+.site-footer .footer-family {
+  margin: 1.6rem 0 0;
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--line);
+  font-size: .86rem;
+}
+
+.site-footer .footer-family span { color: var(--muted); font-weight: 600; }
+
+.site-footer .footer-family a {
+  display: inline-block;
+  margin: .15rem .1rem .15rem .55rem;
+  white-space: nowrap;
+}
+
+/* ==========================================================================
+   Motion preferences
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+
+  *, *::before, *::after {
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+  }
+}
+
+/* ==========================================================================
+   Small screens
+   ========================================================================== */
+
+@media screen and (max-width: 600px) {
+  body { font-size: 16px; }
+
+  .wrapper { padding-left: 18px; padding-right: 18px; }
+
+  .page-content > .wrapper > h1:first-child,
+  .page-content .post-content > h1:first-child,
+  .page-content .home > h1:first-child {
+    padding: 1.8rem 1.25rem;
+    font-size: 1.8rem;
+  }
+
+  @supports selector(:has(+ p)) {
+    .page-content > .wrapper > h1:first-child:has(+ p),
+    .page-content .post-content > h1:first-child:has(+ p),
+    .page-content .home > h1:first-child:has(+ p) { padding-bottom: 1.1rem; }
+
+    .page-content > .wrapper > h1:first-child + p,
+    .page-content .post-content > h1:first-child + p,
+    .page-content .home > h1:first-child + p { padding: 0 1.25rem 1.6rem; }
+  }
+
+  .page-content h2 { font-size: 1.34rem; }
 }

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -289,12 +289,14 @@ a {
   box-shadow: 0 4px 14px rgba(255, 122, 24, .32);
 }
 
+/* On mobile the toggle flows inline after the site title. Absolutely
+   positioning it near the hamburger would put it on top of the dropdown
+   panel once the menu is opened. */
 @media screen and (max-width: 600px) {
   .theme-toggle {
-    position: absolute;
-    top: 13px;
-    right: 68px;
-    z-index: 41;
+    position: static;
+    margin: 0 0 0 .6rem;
+    vertical-align: middle;
   }
 }
 

--- a/communitymech.md
+++ b/communitymech.md
@@ -494,9 +494,11 @@ It is part of the [KG-Microbe knowledge graph](/kg-microbe/) ecosystem at Lawren
 
 - **[CultureMech](/culturemech/)** - Single-organism media requirements (10,000+ recipes)
 - **[MediaIngredientMech](/mediaingredientmech/)** - LLM-assisted ingredient curation
+- **[TraitMech](https://culturebotai.github.io/TraitMech/)** - Microbial ecophysiological trait knowledge base
+- **[ProteinTraitsMech](https://culturebotai.github.io/proteintraitsmech/)** - Protein sequence, structure, and function traits
 - **[PFASCommunityAgents](/resources/#pfascommunityagents)** - AI-driven consortium design for PFAS biodegradation
 - **[kg-microbe](/kg-microbe/)** - Central knowledge graph (864K+ species)
-- **[MicroGrowAgents](/resources/#microgrowagents)** - Multi-agent media design system
+- **[MicroGrowAgents](/microgrowagents/)** - Multi-agent media design system
 
 ---
 
@@ -506,7 +508,7 @@ It is part of the [KG-Microbe knowledge graph](/kg-microbe/) ecosystem at Lawren
 
 If you use CommunityMech in your research, please cite:
 
-> Joachimiak MP, et al. (2025). KG-Microbe: A modular knowledge graph for microbial cultivation. *bioRxiv*. doi: [10.1101/2025.02.24.639989](https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1)
+> Santangelo BE, et al. (2026). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. *GigaScience*, giag077. doi: [10.1093/gigascience/giag077](https://doi.org/10.1093/gigascience/giag077)
 
 ### Related Publications
 

--- a/culturemech.md
+++ b/culturemech.md
@@ -84,7 +84,7 @@ CultureMech Knowledge Graph
 - **Feeds Into**:
   - [MicroMediaParam](/resources/#micromediaparam) - Chemical compound standardization (78% ChEBI coverage)
   - [kg-microbe](/kg-microbe/) - Central knowledge graph integration
-  - [MicroGrowAgents](/resources/#microgrowagents) - AI-driven media design
+  - [MicroGrowAgents](/microgrowagents/) - AI-driven media design
   - [MicroGrowLink](/resources/#microgrowlink) - Graph-based growth predictions
 
 - **Works With**:
@@ -211,6 +211,8 @@ kg.export(format="json", output="media_data.json")
 
 - **[MediaIngredientMech](/mediaingredientmech/)** - LLM-assisted ingredient ontology mapping
 - **[CommunityMech](/communitymech/)** - Microbial community interaction modeling
+- **[TraitMech](https://culturebotai.github.io/TraitMech/)** - Microbial ecophysiological trait knowledge base
+- **[ProteinTraitsMech](https://culturebotai.github.io/proteintraitsmech/)** - Protein sequence, structure, and function traits
 - **[MicroMediaParam](/resources/#micromediaparam)** - Chemical compound standardization and ChEBI mapping
 - **[kg-microbe](/kg-microbe/)** - Central knowledge graph for microbial cultivation
 
@@ -225,7 +227,7 @@ CultureMech is part of the [KG-Microbe knowledge graph](/kg-microbe/) ecosystem 
 - Systematic analysis of microbial growth requirements
 - Evidence-based media design for novel organisms
 
-**Citation**: See the [KG-Microbe preprint](https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1) for details on the broader knowledge graph ecosystem.
+**Citation**: See the [KG-Microbe publication](https://doi.org/10.1093/gigascience/giag077) in *GigaScience* for details on the broader knowledge graph ecosystem.
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -30,11 +30,14 @@ Our primary research areas include:
 ### 🧬 [KG-Microbe Knowledge Graph](https://github.com/Knowledge-Graph-Hub/kg-microbe)
 The comprehensive modular knowledge graph that powers CultureBotAI, developed by Dr. Marcin P. Joachimiak. This resource integrates diverse microbial data to enable AI-driven insights.
 
-### 📄 [KG-Microbe Preprint](https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1)
-Read our bioRxiv preprint by Dr. Marcin P. Joachimiak detailing the development and applications of the KG-Microbe knowledge graph.
+### 📄 [KG-Microbe Publication](https://doi.org/10.1093/gigascience/giag077)
+Read our peer-reviewed *GigaScience* paper by Dr. Marcin P. Joachimiak detailing the development and applications of the KG-Microbe knowledge graph.
 
 ### 🤖 [AI Curation Tools — X-Mech Suite](/culturemech/)
-The X-Mech suite ([CultureMech](/culturemech/), [MediaIngredientMech](/mediaingredientmech/), [CommunityMech](/communitymech/)) provides AI-powered curation of microbial cultivation records, transforming unstructured literature data into standardized knowledge graphs with 10,000+ media recipes.
+The X-Mech suite ([CultureMech](/culturemech/), [MediaIngredientMech](/mediaingredientmech/), [CommunityMech](/communitymech/), [TraitMech](https://culturebotai.github.io/TraitMech/), [ProteinTraitsMech](https://culturebotai.github.io/proteintraitsmech/)) provides AI-powered curation of microbial cultivation records, transforming unstructured literature data into standardized knowledge graphs with 10,000+ media recipes, 477 ecophysiological traits, and 400,000+ protein traits.
+
+### 🧠 [MicroGrowAgents](/microgrowagents/)
+Multi-agent AI system for microbial cultivation and growth media design across 864,363 validated species — [GitHub repository](https://github.com/CultureBotAI/MicroGrowAgents) · [bioRxiv preprint](https://doi.org/10.64898/2026.06.04.729985)
 
 ### 📊 [METPO Ontology](https://github.com/Knowledge-Graph-Hub/kg-microbe/tree/main/src/kg_microbe/transform/metpo)
 Microbial experimental and theoretical preference ontology for standardizing growth preference data.
@@ -71,14 +74,15 @@ CultureBotAI is based at Lawrence Berkeley National Laboratory in Berkeley, Cali
 KG-Microbe is a comprehensive modular knowledge graph developed by Dr. Marcin P. Joachimiak that integrates diverse microbial data sources to enable AI-driven insights for growth prediction and culture optimization.
 
 ### How can I access KG-Microbe?
-KG-Microbe is available on GitHub at https://github.com/Knowledge-Graph-Hub/kg-microbe under the BSD-3-Clause license. The preprint is available at https://doi.org/10.1101/2025.02.24.639989
+KG-Microbe is available on GitHub at https://github.com/Knowledge-Graph-Hub/kg-microbe under the BSD-3-Clause license. The publication is available in GigaScience at https://doi.org/10.1093/gigascience/giag077
 
 ---
 
 ## Quick Links
 
 - 🔬 [Research Areas](/research) - Detailed overview of our research focus
-- 🤖 [AI Curation Tools](/culturemech/) - X-Mech suite (CultureMech, MediaIngredientMech, CommunityMech)
+- 🤖 [AI Curation Tools](/culturemech/) - X-Mech suite (CultureMech, MediaIngredientMech, CommunityMech, TraitMech, ProteinTraitsMech)
+- 🧠 [MicroGrowAgents](/microgrowagents/) - Multi-agent AI for media design
 - 📚 [Resources](/resources) - Tools, databases, and knowledge graphs
 - 📄 [Publications](/publications) - Papers, preprints, and presentations
 - 👥 [About](/about) - Team information and lab details

--- a/kg-microbe.md
+++ b/kg-microbe.md
@@ -73,7 +73,7 @@ The kg-microbe knowledge graph serves as the foundation for numerous CultureBotA
 - **[auto-term-catalog](/resources/#auto-term-catalog---automated-term-extraction)** - OntoGPT term extraction for ontology grounding
 
 ### Prediction & Analysis Tools
-- **[MicroGrowAgents](/resources/#microgrowagents)** - Multi-agent system using kg-microbe for evidence-based media design
+- **[MicroGrowAgents](/microgrowagents/)** - Multi-agent system using kg-microbe for evidence-based media design
 - **MicroGrowLink** - Graph transformer models trained on kg-microbe structure *(private repo, public release planned)*
 - **[neurosymbolreason](/resources/#neurosymbolreason---neurosymbolic-analogy-reasoning)** - Neurosymbolic analogy reasoning over kg-microbe embeddings
 - **[microbe-rules](/resources/#microbe-rules-machine-learning-models-for-microbial-data)** - ML model comparison framework
@@ -101,24 +101,24 @@ The kg-microbe knowledge graph serves as the foundation for numerous CultureBotA
 
 ## Citation
 
-If you use KG-Microbe in your research, please cite our preprint:
+If you use KG-Microbe in your research, please cite our GigaScience paper:
 
 ### APA Format
-Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L. E., Lozupone, C. A., Mungall, C. J., & Joachimiak, M. P. (2025). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. *bioRxiv*. https://doi.org/10.1101/2025.02.24.639989
+Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L. E., Lozupone, C. A., Mungall, C. J., & Joachimiak, M. P. (2026). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. *GigaScience*, giag077. https://doi.org/10.1093/gigascience/giag077
 
 ### BibTeX
 ```bibtex
-@article{santangelo2025kgmicrobe,
+@article{santangelo2026kgmicrobe,
   title={KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences},
   author={Santangelo, Brook E and Hegde, Harshad and Caufield, J Harry and Reese, Justin and Kliegr, Tomas and Hunter, Lawrence E and Lozupone, Catherine A and Mungall, Christopher J and Joachimiak, Marcin P},
-  journal={bioRxiv},
-  year={2025},
-  doi={10.1101/2025.02.24.639989},
-  url={https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1}
+  journal={GigaScience},
+  year={2026},
+  doi={10.1093/gigascience/giag077},
+  url={https://doi.org/10.1093/gigascience/giag077}
 }
 ```
 
-**DOI:** [10.1101/2025.02.24.639989](https://doi.org/10.1101/2025.02.24.639989)
+**DOI:** [10.1093/gigascience/giag077](https://doi.org/10.1093/gigascience/giag077)
 
 ## Related Resources
 
@@ -153,7 +153,7 @@ KG-Microbe is freely available on GitHub at https://github.com/Knowledge-Graph-H
 KG-Microbe uses a modular architecture with scalable design, flexible integration of new data sources and ontologies, and standardized frameworks across all modules for easy expansion and maintenance.
 
 ### How do I cite KG-Microbe?
-Cite the bioRxiv preprint: Santangelo, B. E., et al. (2025). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. bioRxiv. https://doi.org/10.1101/2025.02.24.639989
+Cite the GigaScience article: Santangelo, B. E., et al. (2026). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. GigaScience, giag077. https://doi.org/10.1093/gigascience/giag077
 
 ---
 

--- a/marcin-joachimiak.md
+++ b/marcin-joachimiak.md
@@ -7,7 +7,7 @@ permalink: /marcin-joachimiak/
 
 # Dr. Marcin P. Joachimiak — Principal Investigator
 
-Dr. Marcin P. Joachimiak leads CultureBotAI and the development of KG-Microbe, a groundbreaking knowledge graph for microbiology research. As a staff researcher at Lawrence Berkeley National Laboratory (LBNL) and member of the Berkeley Bioinformatics Open-source Projects (BBOP), Dr. Joachimiak bridges artificial intelligence and microbial cultivation to advance microbiological discoveries.
+Dr. Marcin P. Joachimiak leads CultureBotAI and the development of KG-Microbe, the first comprehensive and ontology-grounded knowledge graph for microbiology research. As a staff researcher at Lawrence Berkeley National Laboratory (LBNL) and member of the Berkeley Bioinformatics Open-source Projects (BBOP), Dr. Joachimiak bridges artificial intelligence and microbial cultivation to advance microbiological discoveries.
 
 ## Research Focus
 
@@ -43,10 +43,10 @@ Creator of the Microbial Experimental and Theoretical Preference Ontology, provi
 
 ## Selected Publications
 
-### Recent Preprint
-**Joachimiak, M.P.** (2025). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. *bioRxiv*. [https://doi.org/10.1101/2025.02.24.639989](https://doi.org/10.1101/2025.02.24.639989)
+### Recent Publication
+Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L. E., Lozupone, C. A., Mungall, C. J., & **Joachimiak, M. P.** (2026). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. *GigaScience*, giag077. [10.1093/gigascience/giag077](https://doi.org/10.1093/gigascience/giag077)
 
-*This comprehensive preprint describes the development, architecture, and applications of KG-Microbe, demonstrating its potential for advancing microbiology research through AI-driven knowledge discovery.*
+*This peer-reviewed article describes the development, architecture, and applications of KG-Microbe, demonstrating its potential for advancing microbiology research through AI-driven knowledge discovery.*
 
 ## Academic Profiles and Links
 

--- a/mediaingredientmech.md
+++ b/mediaingredientmech.md
@@ -87,7 +87,7 @@ Export to Knowledge Graph
 - **Feeds Into**:
   - [MicroMediaParam](/resources/#micromediaparam) - Enhanced ingredient standardization
   - [kg-microbe](/kg-microbe/) - Ontology-grounded knowledge graph
-  - [MicroGrowAgents](/resources/#microgrowagents) - Evidence-based media design
+  - [MicroGrowAgents](/microgrowagents/) - Evidence-based media design
 
 - **Complements**:
   - [CultureMech](/culturemech/) - Chemical entity extraction
@@ -341,6 +341,8 @@ It is part of the [KG-Microbe knowledge graph](/kg-microbe/) project at Lawrence
 
 - **[CultureMech](/culturemech/)** - Chemical entity extraction from media recipes (10,000+ recipes)
 - **[CommunityMech](/communitymech/)** - Microbial community interaction modeling
+- **[TraitMech](https://culturebotai.github.io/TraitMech/)** - Microbial ecophysiological trait knowledge base
+- **[ProteinTraitsMech](https://culturebotai.github.io/proteintraitsmech/)** - Protein sequence, structure, and function traits
 - **[MicroMediaParam](/resources/#micromediaparam)** - Chemical compound standardization (78% ChEBI coverage)
 - **[kg-microbe](/kg-microbe/)** - Central knowledge graph for microbial cultivation
 
@@ -377,7 +379,7 @@ For questions about MediaIngredientMech or to contribute:
 
 ## Citation
 
-If you use MediaIngredientMech in your research, please cite the [KG-Microbe preprint](https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1) and reference this tool:
+If you use MediaIngredientMech in your research, please cite the [KG-Microbe publication](https://doi.org/10.1093/gigascience/giag077) and reference this tool:
 
 ```
 MediaIngredientMech: LLM-Assisted Media Ingredient Curation

--- a/microgrowagents.md
+++ b/microgrowagents.md
@@ -76,6 +76,7 @@ Organism-Specific Media Recommendation
 ## Repository & Documentation
 
 - **GitHub**: [github.com/CultureBotAI/MicroGrowAgents](https://github.com/CultureBotAI/MicroGrowAgents)
+- **Preprint**: [MicroGrowAgents: An Agentic AI System for Microbial Cultivation Engineering](https://doi.org/10.64898/2026.06.04.729985) (bioRxiv, 2026)
 - **License**: BSD-3-Clause
 - **Languages**: Python, HTML, Shell, R
 - **Topics**: `ai4curation` · `monarchinitiative`
@@ -87,6 +88,8 @@ Organism-Specific Media Recommendation
 - **[CultureMech](/culturemech/)** - Microbial culture media knowledge graph (10,000+ recipes)
 - **[MediaIngredientMech](/mediaingredientmech/)** - LLM-assisted ingredient ontology mapping
 - **[CommunityMech](/communitymech/)** - Microbial community interaction modeling
+- **[TraitMech](https://culturebotai.github.io/TraitMech/)** - Microbial ecophysiological trait knowledge base
+- **[ProteinTraitsMech](https://culturebotai.github.io/proteintraitsmech/)** - Protein sequence, structure, and function traits
 - **[MicroGrowLink](/resources/#microgrowlink)** - Graph-based growth media prediction
 - **[kg-microbe](/kg-microbe/)** - Central knowledge graph for microbial cultivation
 
@@ -101,7 +104,9 @@ MicroGrowAgents is part of the [KG-Microbe knowledge graph](/kg-microbe/) ecosys
 - Evidence-based cultivation protocol synthesis from literature
 - Data-driven cultivation optimization
 
-**Citation**: See the [KG-Microbe preprint](https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1) for details on the broader knowledge graph ecosystem.
+**Citation**: Naseem, S., Miller, M. A., Martinez-Gomez, N. C., Sun, N., & Joachimiak, M. P. (2026). MicroGrowAgents: An Agentic AI System for Microbial Cultivation Engineering. *bioRxiv*. [10.64898/2026.06.04.729985](https://doi.org/10.64898/2026.06.04.729985)
+
+See also the [KG-Microbe publication](https://doi.org/10.1093/gigascience/giag077) in *GigaScience* for details on the broader knowledge graph ecosystem.
 
 ---
 

--- a/publications.md
+++ b/publications.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Publications"
-description: "Peer-reviewed publications by Dr. Marcin P. Joachimiak on KG-Microbe knowledge graph development and AI applications in microbial cultivation."
+description: "Peer-reviewed publications and preprints by Dr. Marcin P. Joachimiak on KG-Microbe knowledge graph development and AI applications in microbial cultivation."
 permalink: /publications/
 ---
 

--- a/publications.md
+++ b/publications.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Publications"
-description: "Research publications and preprints by Dr. Marcin P. Joachimiak on KG-Microbe knowledge graph development and AI applications in microbial cultivation."
+description: "Peer-reviewed publications by Dr. Marcin P. Joachimiak on KG-Microbe knowledge graph development and AI applications in microbial cultivation."
 permalink: /publications/
 ---
 
@@ -9,16 +9,29 @@ permalink: /publications/
 
 Our research outputs led by Dr. Marcin P. Joachimiak span KG-Microbe knowledge graph development, AI applications in microbiology, and computational approaches to microbial cultivation.
 
-## 📄 Preprints
+## 📄 Journal Articles
 
 ### KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences
 
 **Full Citation (APA):**
-Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L. E., Lozupone, C. A., Mungall, C. J., & Joachimiak, M. P. (2025). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. *bioRxiv*. https://doi.org/10.1101/2025.02.24.639989
+Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L. E., Lozupone, C. A., Mungall, C. J., & Joachimiak, M. P. (2026). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. *GigaScience*, giag077. https://doi.org/10.1093/gigascience/giag077
 
-**DOI:** [10.1101/2025.02.24.639989](https://doi.org/10.1101/2025.02.24.639989)
+**DOI:** [10.1093/gigascience/giag077](https://doi.org/10.1093/gigascience/giag077)
 
-**Preprint URL:** [https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1](https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1)
+**Article URL:** [https://doi.org/10.1093/gigascience/giag077](https://doi.org/10.1093/gigascience/giag077)
+
+---
+
+## 📝 Preprints
+
+### MicroGrowAgents: An Agentic AI System for Microbial Cultivation Engineering
+
+**Full Citation (APA):**
+Naseem, S., Miller, M. A., Martinez-Gomez, N. C., Sun, N., & Joachimiak, M. P. (2026). MicroGrowAgents: An Agentic AI System for Microbial Cultivation Engineering. *bioRxiv*. https://doi.org/10.64898/2026.06.04.729985
+
+**DOI:** [10.64898/2026.06.04.729985](https://doi.org/10.64898/2026.06.04.729985)
+
+**Project page:** [MicroGrowAgents](/microgrowagents/)
 
 ---
 
@@ -42,13 +55,13 @@ Joachimiak, M. P., Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kli
 
 ### Primary Citation for CultureBotAI Work
 ```bibtex
-@article{santangelo2025kgmicrobe,
+@article{santangelo2026kgmicrobe,
   title={KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences},
   author={Santangelo, Brook E and Hegde, Harshad and Caufield, J Harry and Reese, Justin and Kliegr, Tomas and Hunter, Lawrence E and Lozupone, Catherine A and Mungall, Christopher J and Joachimiak, Marcin P},
-  journal={bioRxiv},
-  year={2025},
-  doi={10.1101/2025.02.24.639989},
-  url={https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1}
+  journal={GigaScience},
+  year={2026},
+  doi={10.1093/gigascience/giag077},
+  url={https://doi.org/10.1093/gigascience/giag077}
 }
 ```
 
@@ -80,10 +93,10 @@ We welcome collaboration opportunities and are open to:
 ## Frequently Asked Questions
 
 ### How do I cite CultureBotAI's work?
-Cite the primary publication: Santangelo, B. E., et al. (2025). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. bioRxiv. https://doi.org/10.1101/2025.02.24.639989
+Cite the primary publication: Santangelo, B. E., et al. (2026). KG-Microbe - Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. GigaScience, giag077. https://doi.org/10.1093/gigascience/giag077
 
-### What is the DOI for the KG-Microbe preprint?
-The DOI is 10.1101/2025.02.24.639989, available at https://doi.org/10.1101/2025.02.24.639989
+### What is the DOI for the KG-Microbe publication?
+The DOI is 10.1093/gigascience/giag077, available at https://doi.org/10.1093/gigascience/giag077
 
 ### Where can I find Dr. Joachimiak's publications?
 Dr. Joachimiak's publications are listed on Google Scholar at https://scholar.google.com/citations?user=zSlIlYQAAAAJ&hl=en and ORCID at https://orcid.org/0000-0001-8175-045X

--- a/research.md
+++ b/research.md
@@ -102,7 +102,7 @@ Expanding kg-microbe capabilities for:
 Our research goals are enabled by a suite of interconnected software tools:
 
 ### For Cultivation of Novel Organisms
-- [MicroGrowAgents](/resources/#microgrowagents) - AI-driven media design with multi-agent reasoning
+- [MicroGrowAgents](/microgrowagents/) - AI-driven media design with multi-agent reasoning
 - [MicroGrowLink](/resources/#microgrowlink) - Graph-based growth prediction using transformers *(private repo, public release planned)*
 - [MATE-LLM](/resources/#mate-llm) - Literature protocol extraction with LLMs *(private repo, public release planned)*
 

--- a/resources.md
+++ b/resources.md
@@ -14,7 +14,7 @@ CultureBotAI led by Dr. Marcin P. Joachimiak develops and maintains various comp
 **New to CultureBotAI?** Start with [Project Ecosystem & Workflows](#project-ecosystem--workflows) to understand how tools work together.
 
 **Looking for specific tools?**
-- [AI Curation Tools](#-ai-curation-tools) - CultureMech, MediaIngredientMech, CommunityMech (NEW!)
+- [AI Curation Tools](#-ai-curation-tools) - CultureMech, MediaIngredientMech, CommunityMech, TraitMech, ProteinTraitsMech
 - [Growth Media Prediction](#growth-media-prediction--design) - MicroGrowLink, MicroGrowAgents
 - [Chemical Data Processing](#micromediaparam) - CultureMech, MicroMediaParam
 - [Genome Analysis](#data-processing--analysis) - eggnog_runner, eggnogtable
@@ -30,7 +30,7 @@ CultureBotAI led by Dr. Marcin P. Joachimiak develops and maintains various comp
 ### Overview
 [KG-Microbe](https://github.com/Knowledge-Graph-Hub/kg-microbe) is our flagship resource developed by Dr. Marcin P. Joachimiak - a comprehensive knowledge graph that integrates diverse microbial data sources to enable AI-driven insights and predictions.
 
-**📄 [Read the Preprint](https://www.biorxiv.org/content/10.1101/2025.02.24.639989v1)** - bioRxiv publication detailing kg-microbe development and applications.
+**📄 [Read the Publication](https://doi.org/10.1093/gigascience/giag077)** - *GigaScience* article detailing kg-microbe development and applications.
 
 ### 📋 METPO Ontology Integration
 
@@ -129,7 +129,7 @@ The CultureBotAI toolkit consists of interconnected projects organized into a da
 
 ## 🤖 AI Curation Tools
 
-The **X-Mech Suite** (CultureMech, MediaIngredientMech, CommunityMech) forms the AI-powered curation pipeline that transforms unstructured microbial cultivation data from literature and laboratory records into standardized, machine-readable knowledge graphs.
+The **X-Mech Suite** (CultureMech, MediaIngredientMech, CommunityMech, TraitMech, ProteinTraitsMech) forms the AI-powered curation pipeline that transforms unstructured microbial cultivation data from literature, laboratory records, and sequence data into standardized, machine-readable knowledge graphs.
 
 ### Pipeline Overview
 
@@ -179,6 +179,24 @@ LinkML-based modeling of microbial communities with evidence-based ecological in
 **Related**: Powers [PFASCommunityAgents](#pfascommunityagents) for AI-driven consortium design.
 
 **→ [Learn more on the dedicated CommunityMech page](/communitymech/)**
+
+---
+
+### TraitMech - Microbial Ecophysiological Traits
+**[GitHub Repository](https://github.com/CultureBotAI/TraitMech)** | **[Web Interface](https://culturebotai.github.io/TraitMech/)** | CC0-1.0 License
+
+Microbial ecophysiological trait knowledge base seeded from METPO and curated incrementally — 477 trait records across 9 categories, each with definitions, causal graphs, and kg-microbe matches.
+
+**What it does**: Standardizes the trait vocabulary used to describe microbial growth and ecology, and links each trait to its evidence and to kg-microbe.
+
+---
+
+### ProteinTraitsMech - Protein Sequence & Structure Traits
+**[GitHub Repository](https://github.com/CultureBotAI/proteintraitsmech)** | **[Web Interface](https://culturebotai.github.io/proteintraitsmech/)** | CC0-1.0 License
+
+Knowledge base of protein sequence, structure, and function traits — 400,000+ LinkML-validated records from 29 sources, one YAML per trait, with evidence-backed causal graphs.
+
+**What it does**: Extends trait curation from the organism level to the molecular level, connecting protein features to the phenotypes they help explain.
 
 ---
 
@@ -635,9 +653,9 @@ If you use kg-microbe or other CultureBotAI resources in your research, please c
 
 ```
 Santangelo, B.E., Hegde, H., Caufield, J.H., Reese, J., Kliegr, T., Hunter, L.E., 
-Lozupone, C.A., Mungall, C.J., Joachimiak, M.P. (2025). KG-Microbe - Building 
+Lozupone, C.A., Mungall, C.J., Joachimiak, M.P. (2026). KG-Microbe - Building 
 Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. 
-bioRxiv. https://doi.org/10.1101/2025.02.24.639989
+GigaScience, giag077. https://doi.org/10.1093/gigascience/giag077
 ```
 
 ---


### PR DESCRIPTION
## Summary

Two commits: a visual theme refresh for the site, and a batch of content corrections.

**Theme** — restyles the Minima base with a peach `#FFD8B2` / sage `#DDE8DF` palette, burnt-orange accent `#C25E12`, and neon orange/mint `#FF7A18` / `#2FE0A0` for rules, glows and hover states. The palette is deliberately unused by any sibling X-Mech site (pink/blue, teal/amber, gray/red, aqua/purple, green) while keeping the same light, positive language: pastel hero gradient, rounded cards, pill nav, soft shadows.

- Hero card merging page title with lede paragraph; self-contained title card on pages without one (`:has()`, `@supports`-guarded)
- Sticky translucent header, neon top hairline, current-page nav pill (marked client-side — Minima does not do this)
- Light/dark toggle, preference applied in `<head>` before first paint so there is no flash
- Rouge token colours remapped onto theme variables so code blocks read correctly in dark mode
- New `_includes/footer.html`: the theme default rendered the `site.author` mapping as a raw Ruby hash on every page

**Content**

- Every KG-Microbe bioRxiv reference replaced with the published article: Santangelo et al. (2026) *GigaScience*, giag077, doi:10.1093/gigascience/giag077 — citation blocks, BibTeX, FAQ answers, and the JSON-LD `ScholarlyArticle`
- MicroGrowAgents added to Key Resources with repo and preprint (Naseem et al. 2026, doi:10.64898/2026.06.04.729985), cited on its own page and listed in publications.md
- TraitMech and ProteinTraitsMech added everywhere the X-Mech suite is enumerated, linking to their own GitHub Pages sites
- KG-Microbe described as "the first comprehensive and ontology-grounded" rather than "groundbreaking"

## Testing

Jekyll could not be built locally (system Ruby is 2.6; the `github-pages` bundle needs >= 3.0). Instead the live site's rendered markup was re-rendered against the new CSS in headless Chrome and checked in light mode, dark mode, and at mobile width. CSS was checked for balanced delimiters. The dark-theme colour for the active nav pill is verified by inspection only, not visually.

Merging deploys to https://culturebotai.github.io automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)