### PR TITLE
Keep bibliography numbering continuous

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -24,6 +24,7 @@ Every publication, preprint, and software record from this work, with resolvable
 3. Naseem S, Miller MA, Martinez-Gomez NC, Sun N, **Joachimiak MP**. MicroGrowAgents: An Agentic AI System for Microbial Cultivation Engineering. *bioRxiv*. 2026. [doi:10.64898/2026.06.04.729985](https://doi.org/10.64898/2026.06.04.729985)
 
    Project page: [MicroGrowAgents](/microgrowagents/)
+{: start="3"}
 
 ### Software and Data Records
 
@@ -40,12 +41,14 @@ Every publication, preprint, and software record from this work, with resolvable
 7. **Joachimiak MP**. KG-Microbe — Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences [workflow]. WorkflowHub; v1. [doi:10.48546/workflowhub.workflow.2044.1](https://doi.org/10.48546/workflowhub.workflow.2044.1) · [WorkflowHub 2044](https://workflowhub.eu/workflows/2044)
 
    The registered knowledge-graph construction workflow. License: BSD-3-Clause.
+{: start="4"}
 
 ### Talks and Presentations
 
 8. **Joachimiak MP**. "Knowledge-Graph-driven and LLM-enhanced Microbial…" BOKR COSI, ISMB/ECCB 2025. [Recording (ISCB)](https://www.youtube.com/watch?v=TgSUbOWQHfI)
 
    The recording is published by ISCB under the title shown, which the uploader truncated.
+{: start="8"}
 
 ### Related Work from the Group
 
@@ -58,6 +61,7 @@ Methods and infrastructure this work builds on, co-authored by Dr. Joachimiak.
 11. **Joachimiak MP**, Miller MA, Caufield JH, Ly R, Harris NL, et al. The Artificial Intelligence Ontology: LLM-Assisted Construction of AI Concept Hierarchies. *Applied Ontology*. 2024;19:408–418. [doi:10.1177/15705838241304103](https://doi.org/10.1177/15705838241304103)
 
 12. Clark T, Caufield H, Parker JA, Al Manir S, Amorim E, et al. (31 authors, incl. **Joachimiak M**). AI-readiness criteria for biomedical data. *bioRxiv*. 2026 (v6; first posted 2024). [doi:10.1101/2024.10.23.619844](https://doi.org/10.1101/2024.10.23.619844)
+{: start="9"}
 
 ---
 


### PR DESCRIPTION
The section headings inside publications.md's bibliography split it into five separate `<ol>` elements, each restarting at 1 — so the MicroGrowAgents preprint rendered as "1." under Preprints, KOGUT as "1." under Software and Data Records, and so on. Duplicate numbers in a list whose numbers are the referencing mechanism.

Adds kramdown `{: start="N"}` IALs so the rendered list runs 1–12 and matches the source.

Caught on the deployed page — this cannot be verified without a real Jekyll build, which does not run locally (system Ruby is 2.6; the `github-pages` bundle needs >= 3.0). Will confirm against the live page after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)