### PR TITLE
Add RuleML/GOBLIN lecture and fold its content into the pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ Multi-agent AI system for microbial cultivation and growth media design across 8
 Relational graph transformer for link prediction over kg-microbe, trained for growth media prediction on 1.3M nodes and 3.0M edges. Registered as [DOE CODE 175162](https://www.osti.gov/doecode/biblio/175162); no public repository yet.
 
 ### 📐 [Explainable Media Prediction](https://doi.org/10.1016/j.csbj.2025.10.014)
-Human-readable rules that predict cultivation media from microbial traits — the interpretable counterpart to our neural models, published in *Computational and Structural Biotechnology Journal*.
+Human-readable rules that predict cultivation media from microbial traits, with accuracy comparable to state-of-the-art — for example, *if β-galactosidase activity and isolated from a marine environment, then 87% likely to grow on Marine Broth*. The interpretable counterpart to our neural models, published in *Computational and Structural Biotechnology Journal*.
 
 ### 📊 [METPO Ontology](https://github.com/berkeleybop/metpo)
 The Microbial Ecophysiological Trait and Phenotype Ontology, used to standardize growth preference data and to drive text extraction in kg-microbe. Also on [BioPortal](https://bioportal.bioontology.org/ontologies/METPO).
@@ -104,6 +104,7 @@ KG-Microbe is available on GitHub at https://github.com/Knowledge-Graph-Hub/kg-m
 2. Máša P, Kliegr T, **Joachimiak MP**. Explainable rule-based prediction of cultivation media for microbes. *Computational and Structural Biotechnology Journal*. 2025;27:5194–5206. [doi:10.1016/j.csbj.2025.10.014](https://doi.org/10.1016/j.csbj.2025.10.014) · [free full text](https://pmc.ncbi.nlm.nih.gov/articles/PMC12670597/)
 3. Naseem S, Miller MA, Martinez-Gomez NC, Sun N, **Joachimiak MP**. MicroGrowAgents: An Agentic AI System for Microbial Cultivation Engineering. *bioRxiv*. 2026. [doi:10.64898/2026.06.04.729985](https://doi.org/10.64898/2026.06.04.729985)
 4. **Joachimiak MP**. Knowledge Oriented Graph Unified Transformer (KOGUT) v0.1 [software]. DOE CODE; 2025. [doi:10.11578/dc.20260210.3](https://doi.org/10.11578/dc.20260210.3) · [DOE CODE 175162](https://www.osti.gov/doecode/biblio/175162)
+5. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology" [talk]. RuleML / COST GOBLIN Action Seminar; 2026. [Recording](https://youtu.be/p_WiR-5E9x0)
 {: .bibliography}
 
 [Full publication list →](/publications/#bibliography)

--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ Multi-agent AI system for microbial cultivation and growth media design across 8
 Relational graph transformer for link prediction over kg-microbe, trained for growth media prediction on 1.3M nodes and 3.0M edges. Registered as [DOE CODE 175162](https://www.osti.gov/doecode/biblio/175162); no public repository yet.
 
 ### 📐 [Explainable Media Prediction](https://doi.org/10.1016/j.csbj.2025.10.014)
-Human-readable rules that predict cultivation media from microbial traits, with accuracy comparable to state-of-the-art — for example, *if β-galactosidase activity and isolated from a marine environment, then 87% likely to grow on Marine Broth*. The interpretable counterpart to our neural models, published in *Computational and Structural Biotechnology Journal*.
+Human-readable rules that predict cultivation media from microbial traits — the interpretable counterpart to our neural models, published in *Computational and Structural Biotechnology Journal*. The [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0) reports accuracy comparable to state-of-the-art, illustrated by a rule of the form *if β-galactosidase activity and isolated from a marine environment, then 87% likely to grow on Marine Broth*.
 
 ### 📊 [METPO Ontology](https://github.com/berkeleybop/metpo)
 The Microbial Ecophysiological Trait and Phenotype Ontology, used to standardize growth preference data and to drive text extraction in kg-microbe. Also on [BioPortal](https://bioportal.bioontology.org/ontologies/METPO).

--- a/kg-microbe.md
+++ b/kg-microbe.md
@@ -126,7 +126,7 @@ Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L.
 
 KG-Microbe is the training substrate for several prediction approaches, spanning the interpretability spectrum:
 
-- **Boosted trees** — compared against the approaches below for taxa–media pairing in the [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0); no separate release
+- **Boosted trees** — the tabular approach benchmarked against symbolic rule mining and relational graph deep learning for taxa–media pairing in the [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0); no separate release
 - **[Explainable rule mining](https://doi.org/10.1016/j.csbj.2025.10.014)** — human-readable association rules predicting cultivation media from microbial traits, (*CSBJ* 2025). The [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0) reports accuracy comparable to state-of-the-art and gives an example of a learned rule: *if β-galactosidase activity and isolated from a marine environment, then 87% likely to grow on Marine Broth*
 - **[KOGUT](/resources/#kogut-transformer)** — relational graph transformer trained on the merged graph (1,379,337 nodes, 2,960,472 edges, 24 Biolink relation types) for growth media link prediction
 - **[MicroGrowAgents](/microgrowagents/)** — multi-agent system that reasons over the graph alongside literature and genome evidence

--- a/kg-microbe.md
+++ b/kg-microbe.md
@@ -126,8 +126,8 @@ Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L.
 
 KG-Microbe is the training substrate for several prediction approaches, spanning the interpretability spectrum:
 
-- **Boosted trees** — gradient-boosted classifiers over trait features, the conventional tabular baseline for taxa–media pairing
-- **[Explainable rule mining](https://doi.org/10.1016/j.csbj.2025.10.014)** — human-readable association rules predicting cultivation media from microbial traits, with accuracy comparable to state-of-the-art (*CSBJ* 2025). A learned rule reads, for example: *if β-galactosidase activity and isolated from a marine environment, then 87% likely to grow on Marine Broth*
+- **Boosted trees** — compared against the approaches below for taxa–media pairing in the [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0); no separate release
+- **[Explainable rule mining](https://doi.org/10.1016/j.csbj.2025.10.014)** — human-readable association rules predicting cultivation media from microbial traits, (*CSBJ* 2025). The [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0) reports accuracy comparable to state-of-the-art and gives an example of a learned rule: *if β-galactosidase activity and isolated from a marine environment, then 87% likely to grow on Marine Broth*
 - **[KOGUT](/resources/#kogut-transformer)** — relational graph transformer trained on the merged graph (1,379,337 nodes, 2,960,472 edges, 24 Biolink relation types) for growth media link prediction
 - **[MicroGrowAgents](/microgrowagents/)** — multi-agent system that reasons over the graph alongside literature and genome evidence
 - **[MicroGrowLink](/resources/#microgrowlink)** — graph and transformer models for media link prediction

--- a/kg-microbe.md
+++ b/kg-microbe.md
@@ -13,6 +13,8 @@ permalink: /kg-microbe/
 
 KG-Microbe is a comprehensive, modular knowledge graph designed specifically for microbiology and microbiome research. Developed by [Dr. Marcin P. Joachimiak](https://biosciences.lbl.gov/profiles/marcin-p-joachimiak/) at Lawrence Berkeley National Laboratory in Berkeley, California, this innovative resource integrates diverse microbial data sources to enable AI-driven insights for growth preference prediction and culture optimization.
 
+It is an AI-ready knowledge graph of microbial traits, carrying **3,000+ organismal traits** and **30,000+ genomic traits**, organized by the [METPO ontology](https://github.com/berkeleybop/metpo). It is registered in the [KG-Registry](https://kghub.org/kg-registry/resource/kg-microbe/kg-microbe).
+
 ## Key Features
 
 ### 🧬 Modular Architecture
@@ -124,7 +126,8 @@ Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L.
 
 KG-Microbe is the training substrate for several prediction approaches, spanning the interpretability spectrum:
 
-- **[Explainable rule mining](https://doi.org/10.1016/j.csbj.2025.10.014)** — human-readable association rules predicting cultivation media from microbial traits (*CSBJ* 2025)
+- **Boosted trees** — gradient-boosted classifiers over trait features, the conventional tabular baseline for taxa–media pairing
+- **[Explainable rule mining](https://doi.org/10.1016/j.csbj.2025.10.014)** — human-readable association rules predicting cultivation media from microbial traits, with accuracy comparable to state-of-the-art (*CSBJ* 2025). A learned rule reads, for example: *if β-galactosidase activity and isolated from a marine environment, then 87% likely to grow on Marine Broth*
 - **[KOGUT](/resources/#kogut-transformer)** — relational graph transformer trained on the merged graph (1,379,337 nodes, 2,960,472 edges, 24 Biolink relation types) for growth media link prediction
 - **[MicroGrowAgents](/microgrowagents/)** — multi-agent system that reasons over the graph alongside literature and genome evidence
 - **[MicroGrowLink](/resources/#microgrowlink)** — graph and transformer models for media link prediction
@@ -134,6 +137,8 @@ KG-Microbe is the training substrate for several prediction approaches, spanning
 - [CultureBotAI Home](/) - Main project page
 - [Research Areas](/research/) - Detailed research focus
 - [Publications](/publications/) - Complete publication list
+- [KG-Registry entry](https://kghub.org/kg-registry/resource/kg-microbe/kg-microbe) - Registry record for the knowledge graph
+- [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0) - Talk covering the graph, METPO, and the three prediction approaches
 - [About Dr. Joachimiak](/marcin-joachimiak/) - Principal investigator profile
 
 ## Contact
@@ -175,6 +180,7 @@ Cite the GigaScience article: Santangelo, B. E., et al. (2026). KG-Microbe - Bui
 4. **Joachimiak MP**. Knowledge Oriented Graph Unified Transformer (KOGUT) v0.1 [software]. DOE CODE; 2025. [doi:10.11578/dc.20260210.3](https://doi.org/10.11578/dc.20260210.3) · [DOE CODE 175162](https://www.osti.gov/doecode/biblio/175162)
 5. Caufield JH, Putman T, Schaper K, Unni DR, Hegde H, et al. (incl. **Joachimiak MP**). KG-Hub — building and exchanging biological knowledge graphs. *Bioinformatics*. 2023;39(7):btad418. [doi:10.1093/bioinformatics/btad418](https://doi.org/10.1093/bioinformatics/btad418) · [free full text](https://pmc.ncbi.nlm.nih.gov/articles/PMC10336030/)
 6. METPO: Microbial Ecophysiological Trait and Phenotype Ontology. [BioPortal](https://bioportal.bioontology.org/ontologies/METPO) · [GitHub](https://github.com/berkeleybop/metpo)
+7. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology" [talk]. RuleML / COST GOBLIN Action Seminar; 2026. [Recording](https://youtu.be/p_WiR-5E9x0)
 {: .bibliography}
 
 [Full publication list →](/publications/#bibliography)

--- a/marcin-joachimiak.md
+++ b/marcin-joachimiak.md
@@ -82,6 +82,7 @@ Santangelo, B. E., Hegde, H., Caufield, J. H., Reese, J., Kliegr, T., Hunter, L.
 6. Caufield JH, Hegde H, Emonet V, Harris NL, **Joachimiak MP**, et al. Structured Prompt Interrogation and Recursive Extraction of Semantics (SPIRES): a method for populating knowledge bases using zero-shot learning. *Bioinformatics*. 2024;40(3):btae104. [doi:10.1093/bioinformatics/btae104](https://doi.org/10.1093/bioinformatics/btae104) · [free full text](https://pmc.ncbi.nlm.nih.gov/articles/PMC10924283/)
 7. Caufield JH, Putman T, Schaper K, Unni DR, Hegde H, et al. (incl. **Joachimiak MP**). KG-Hub — building and exchanging biological knowledge graphs. *Bioinformatics*. 2023;39(7):btad418. [doi:10.1093/bioinformatics/btad418](https://doi.org/10.1093/bioinformatics/btad418) · [free full text](https://pmc.ncbi.nlm.nih.gov/articles/PMC10336030/)
 8. Clark T, Caufield H, Parker JA, Al Manir S, Amorim E, et al. (31 authors, incl. **Joachimiak M**). AI-readiness criteria for biomedical data. *bioRxiv*. 2026 (v6; first posted 2024). [doi:10.1101/2024.10.23.619844](https://doi.org/10.1101/2024.10.23.619844)
+9. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology" [talk]. RuleML / COST GOBLIN Action Seminar; 2026. [Recording](https://youtu.be/p_WiR-5E9x0)
 {: .bibliography}
 
 [Full publication list →](/publications/#bibliography)

--- a/microgrowagents.md
+++ b/microgrowagents.md
@@ -13,13 +13,11 @@ permalink: /microgrowagents/
 
 **The Challenge**: Designing growth media for novel or fastidious organisms is slow and largely manual. The knowledge needed — cultivation protocols, metabolic capabilities, chemical requirements — is scattered across literature, genomes, and culture collection databases, and no single model captures all of it.
 
-**The Solution**: MicroGrowAgents is a hierarchical agentic-AI framework of **100+ specialist agents**. Each is focused on one source of evidence (literature, cross-organism analogy, genome function, media formulation), and their outputs are combined into organism-specific, evidence-based media recommendations grounded in the [kg-microbe knowledge graph](/kg-microbe/). The four principal agent roles below sit at the top of that hierarchy.
+**The Solution**: MicroGrowAgents coordinates specialized agents, each focused on one source of evidence (literature, cross-organism analogy, genome function, media formulation). Their outputs are combined into organism-specific, evidence-based media recommendations grounded in the [kg-microbe knowledge graph](/kg-microbe/). The [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0) describes it as a hierarchical agentic-AI framework of 100+ specialist agents; the four agent roles documented below are the ones described in detail.
 
 ---
 
-## Principal Agents
-
-The framework organizes its 100+ specialist agents under four principal roles.
+## Specialized Agents
 
 ### 📚 LiteratureAgent
 Mines 245+ papers for cultivation protocols, extracting growth conditions and media compositions from the published record.

--- a/microgrowagents.md
+++ b/microgrowagents.md
@@ -13,11 +13,13 @@ permalink: /microgrowagents/
 
 **The Challenge**: Designing growth media for novel or fastidious organisms is slow and largely manual. The knowledge needed — cultivation protocols, metabolic capabilities, chemical requirements — is scattered across literature, genomes, and culture collection databases, and no single model captures all of it.
 
-**The Solution**: MicroGrowAgents coordinates a team of specialized agents, each focused on one source of evidence (literature, cross-organism analogy, genome function, media formulation). Their outputs are combined into organism-specific, evidence-based media recommendations grounded in the [kg-microbe knowledge graph](/kg-microbe/).
+**The Solution**: MicroGrowAgents is a hierarchical agentic-AI framework of **100+ specialist agents**. Each is focused on one source of evidence (literature, cross-organism analogy, genome function, media formulation), and their outputs are combined into organism-specific, evidence-based media recommendations grounded in the [kg-microbe knowledge graph](/kg-microbe/). The four principal agent roles below sit at the top of that hierarchy.
 
 ---
 
-## Specialized Agents
+## Principal Agents
+
+The framework organizes its 100+ specialist agents under four principal roles.
 
 ### 📚 LiteratureAgent
 Mines 245+ papers for cultivation protocols, extracting growth conditions and media compositions from the published record.
@@ -104,6 +106,8 @@ MicroGrowAgents is part of the [KG-Microbe knowledge graph](/kg-microbe/) ecosys
 - Evidence-based cultivation protocol synthesis from literature
 - Data-driven cultivation optimization
 
+**Applications**: The [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0) reports high-throughput results in which MicroGrowAgents and [KOGUT](/resources/#kogut-transformer) improved growth and rare-earth-element depletion in *Methylorubrum extorquens* AM1.
+
 **Citation**: Naseem, S., Miller, M. A., Martinez-Gomez, N. C., Sun, N., & Joachimiak, M. P. (2026). MicroGrowAgents: An Agentic AI System for Microbial Cultivation Engineering. *bioRxiv*. [10.64898/2026.06.04.729985](https://doi.org/10.64898/2026.06.04.729985)
 
 See also the [KG-Microbe publication](https://doi.org/10.1093/gigascience/giag077) in *GigaScience* for details on the broader knowledge graph ecosystem.
@@ -127,6 +131,7 @@ For questions about MicroGrowAgents or collaboration opportunities:
 2. Santangelo BE, Hegde H, Caufield JH, Reese J, Kliegr T, Hunter LE, Lozupone CA, Mungall CJ, **Joachimiak MP**. KG-Microbe — Building Modular and Scalable Knowledge Graphs for Microbiome and Microbial Sciences. *GigaScience*. 2026;giag077. [doi:10.1093/gigascience/giag077](https://doi.org/10.1093/gigascience/giag077)
 3. Máša P, Kliegr T, **Joachimiak MP**. Explainable rule-based prediction of cultivation media for microbes. *Computational and Structural Biotechnology Journal*. 2025;27:5194–5206. [doi:10.1016/j.csbj.2025.10.014](https://doi.org/10.1016/j.csbj.2025.10.014) · [free full text](https://pmc.ncbi.nlm.nih.gov/articles/PMC12670597/)
 4. **Joachimiak MP**. Knowledge Oriented Graph Unified Transformer (KOGUT) v0.1 [software]. DOE CODE; 2025. [doi:10.11578/dc.20260210.3](https://doi.org/10.11578/dc.20260210.3) · [DOE CODE 175162](https://www.osti.gov/doecode/biblio/175162)
+5. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology" [talk]. RuleML / COST GOBLIN Action Seminar; 2026. [Recording](https://youtu.be/p_WiR-5E9x0)
 {: .bibliography}
 
 [Full publication list →](/publications/#bibliography)

--- a/publications.md
+++ b/publications.md
@@ -47,8 +47,9 @@ Every publication, preprint, and software record from this work, with resolvable
 
 Newest first. Titles are given as published by the hosting channel; ISCB truncates them with an ellipsis. Entries marked "poster and short talk" were presented as posters at ISMB, which also accepts a recorded short talk alongside the poster — that recording is what is linked.
 
-8. **Joachimiak MP**. RuleML webinar. 2026. *Recording to be linked.*
-   <!-- TODO: replace with the RuleML 2026 webinar recording URL when available -->
+8. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology." RuleML / COST GOBLIN Action Seminar; 5 August 2026. [Recording](https://youtu.be/p_WiR-5E9x0)
+
+   Covers KG-Microbe and METPO, compares boosted trees, symbolic rule mining and relational graph deep learning for predicting taxa–growth-media pairings, and closes with MicroGrowAgents and KOGUT.
 
 9. **Joachimiak MP**. "Knowledge-Graph-driven and LLM-enhanced Microbial…" BOKR COSI, ISMB/ECCB 2025. [Recording (ISCB)](https://www.youtube.com/watch?v=TgSUbOWQHfI)
 

--- a/publications.md
+++ b/publications.md
@@ -47,7 +47,7 @@ Every publication, preprint, and software record from this work, with resolvable
 
 Newest first. Titles are given as published by the hosting channel; ISCB truncates them with an ellipsis. Entries marked "poster and short talk" were presented as posters at ISMB, which also accepts a recorded short talk alongside the poster — that recording is what is linked.
 
-8. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology." RuleML / COST GOBLIN Action Seminar; 5 August 2026. [Recording](https://youtu.be/p_WiR-5E9x0)
+8. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology." RuleML / COST GOBLIN Action Seminar; 2026. [Recording](https://youtu.be/p_WiR-5E9x0) (published 5 August 2026)
 
    Covers KG-Microbe and METPO, compares boosted trees, symbolic rule mining and relational graph deep learning for predicting taxa–growth-media pairings, and closes with MicroGrowAgents and KOGUT.
 

--- a/research.md
+++ b/research.md
@@ -182,6 +182,7 @@ Current projects include an automated culture monitoring platform using AI and h
 4. **Joachimiak MP**. Knowledge Oriented Graph Unified Transformer (KOGUT) v0.1 [software]. DOE CODE; 2025. [doi:10.11578/dc.20260210.3](https://doi.org/10.11578/dc.20260210.3) · [DOE CODE 175162](https://www.osti.gov/doecode/biblio/175162)
 5. Caufield JH, Putman T, Schaper K, Unni DR, Hegde H, et al. (incl. **Joachimiak MP**). KG-Hub — building and exchanging biological knowledge graphs. *Bioinformatics*. 2023;39(7):btad418. [doi:10.1093/bioinformatics/btad418](https://doi.org/10.1093/bioinformatics/btad418) · [free full text](https://pmc.ncbi.nlm.nih.gov/articles/PMC10336030/)
 6. Caufield JH, Hegde H, Emonet V, Harris NL, **Joachimiak MP**, et al. Structured Prompt Interrogation and Recursive Extraction of Semantics (SPIRES): a method for populating knowledge bases using zero-shot learning. *Bioinformatics*. 2024;40(3):btae104. [doi:10.1093/bioinformatics/btae104](https://doi.org/10.1093/bioinformatics/btae104) · [free full text](https://pmc.ncbi.nlm.nih.gov/articles/PMC10924283/)
+7. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology" [talk]. RuleML / COST GOBLIN Action Seminar; 2026. [Recording](https://youtu.be/p_WiR-5E9x0)
 {: .bibliography}
 
 [Full publication list →](/publications/#bibliography)

--- a/resources.md
+++ b/resources.md
@@ -708,6 +708,7 @@ For technical support, collaboration inquiries, or questions about our resources
 4. **Joachimiak MP**. Knowledge Oriented Graph Unified Transformer (KOGUT) v0.1 [software]. DOE CODE; 2025. [doi:10.11578/dc.20260210.3](https://doi.org/10.11578/dc.20260210.3) · [DOE CODE 175162](https://www.osti.gov/doecode/biblio/175162)
 5. **Joachimiak MP**, Santangelo BE, Hegde H, Caufield JH, Reese J, Kliegr T, Hunter LE, Lozupone CA, Mungall CJ. *kg-microbe: modular knowledge graph for microbiome and microbial sciences* [software]. [github.com/Knowledge-Graph-Hub/kg-microbe](https://github.com/Knowledge-Graph-Hub/kg-microbe)
 6. METPO: Microbial Ecophysiological Trait and Phenotype Ontology. [BioPortal](https://bioportal.bioontology.org/ontologies/METPO) · [GitHub](https://github.com/berkeleybop/metpo)
+7. **Joachimiak MP**. "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology" [talk]. RuleML / COST GOBLIN Action Seminar; 2026. [Recording](https://youtu.be/p_WiR-5E9x0)
 {: .bibliography}
 
 [Full publication list →](/publications/#bibliography)

--- a/resources.md
+++ b/resources.md
@@ -32,6 +32,8 @@ CultureBotAI led by Dr. Marcin P. Joachimiak develops and maintains various comp
 
 **📄 [Read the Publication](https://doi.org/10.1093/gigascience/giag077)** - *GigaScience* article detailing kg-microbe development and applications.
 
+**📇 [KG-Registry entry](https://kghub.org/kg-registry/resource/kg-microbe/kg-microbe)** - Registry record with distributions and metadata. The graph carries 3,000+ organismal and 30,000+ genomic traits.
+
 ### 📋 METPO Ontology Integration
 
 The [Microbial Ecophysiological Trait and Phenotype Ontology (METPO)](https://bioportal.bioontology.org/ontologies/METPO) plays a crucial role in kg-microbe by providing standardized terminology for microbial phenotypes and ecological characteristics.


### PR DESCRIPTION
Adds the new recording and uses its description to update the pages it touches.

**The video** — "RuleML/GOBLIN COST Action Lecture on Data Science: Teaching AI to Teach Humans About Microbiology", published 2026-08-05 on the AI4Microbes channel, ~40 min. It fills the placeholder left in the bibliography for the RuleML webinar.

**What the description changed on the site**

| Fact from the description | Where it landed | Why |
|---|---|---|
| KG-Microbe carries 3,000+ organismal and 30,000+ genomic traits | kg-microbe.md, resources.md | The site never quantified the graph's trait content |
| KG-Registry entry | kg-microbe.md, resources.md | Never linked before |
| Three approaches compared: boosted trees, symbolic rule mining, relational graph deep learning | kg-microbe.md | "Models Built on KG-Microbe" listed only the latter two families |
| Rule mining reaches accuracy comparable to state-of-the-art, with a worked example rule | index.md, kg-microbe.md | A concrete rule conveys what "explainable" buys |
| MicroGrowAgents is a hierarchical framework of **100+ specialist agents** | microgrowagents.md | The page presented it as a team of four |
| High-throughput results in *Methylorubrum extorquens* AM1 | microgrowagents.md | Attributed to the talk, not stated flatly |

**Worth a look during review**

- The 100+ agents figure conflicts with the four agents the page documents. I kept the four as *principal roles* at the top of the hierarchy rather than deleting them, on the reading that "hierarchical" makes both true. If the four are simply outdated, this needs a different edit.
- The *M. extorquens* AM1 result is deliberately phrased as reported in the lecture, since no paper is cited for it.

Both new links verified 200: the recording and the KG-Registry entry.