### PR TITLE
Tidy the kg-microbe page: drop unreleased entries, widen the model-training claim

### DIFF
--- a/index.md
+++ b/index.md
@@ -59,7 +59,7 @@ CultureBotAI's projects form an integrated ecosystem built on the [kg-microbe kn
 - **Specialized applications** target specific research domains (PFAS biodegradation, lanthanide bioprocessing)
 - **Web services** provide API access to prediction models
 
-[Explore the complete project ecosystem →](/resources/#project-ecosystem--workflows)
+[Explore the complete project ecosystem →](/resources/#-project-ecosystem--workflows)
 
 ---
 

--- a/kg-microbe.md
+++ b/kg-microbe.md
@@ -70,8 +70,6 @@ The kg-microbe knowledge graph serves as the foundation for numerous CultureBotA
 - **[CultureMech](/culturemech/) & [MicroMediaParam](/resources/#micromediaparam)** - Integrate chemical compound data with standardized identifiers
 - **[MediaIngredientMech](/mediaingredientmech/)** - LLM-assisted ingredient ontology mapping (ChEBI, PubChem, METPO)
 - **[assay-metadata](/resources/#assay-metadata-bacdive-api-assay-metadata-extractor)** - Add phenotypic assay results from 99K+ BacDive strains
-- **MATE-LLM** - Literature-derived cultivation data extraction *(private repo, public release planned)*
-- **eggnog_runner / eggnogtable** - Genome functional annotation pipeline *(eggnogtable is private, public release planned)*
 - **[auto-term-catalog](/resources/#auto-term-catalog---automated-term-extraction)** - OntoGPT term extraction for ontology grounding
 
 ### Prediction & Analysis Tools

--- a/kg-microbe.md
+++ b/kg-microbe.md
@@ -74,14 +74,13 @@ The kg-microbe knowledge graph serves as the foundation for numerous CultureBotA
 
 ### Prediction & Analysis Tools
 - **[MicroGrowAgents](/microgrowagents/)** - Multi-agent system using kg-microbe for evidence-based media design
-- **MicroGrowLink** - Graph transformer models trained on kg-microbe structure *(private repo, public release planned)*
 - **[neurosymbolreason](/resources/#neurosymbolreason---neurosymbolic-analogy-reasoning)** - Neurosymbolic analogy reasoning over kg-microbe embeddings
 - **[microbe-rules](/resources/#microbe-rules-machine-learning-models-for-microbial-data)** - ML model comparison framework
 - **[CommunityMech](/communitymech/)** - Multi-organism community interaction modeling
 - **[PFAS-AI](/resources/#pfas-ai-machine-learning-enabled-pfas-biodegradation-pipeline)** & PFASCommunityAgents - PFAS biodegradation research *(PFASCommunityAgents is private, public release planned)*
 - **CMM-AI** - Lanthanide bioprocessing research leveraging metabolic data *(private repo, public release planned)*
 
-[Explore all projects and their relationships →](/resources/#project-ecosystem--workflows)
+[Explore all projects and their relationships →](/resources/#-project-ecosystem--workflows)
 
 ## Access and Usage
 

--- a/kg-microbe.md
+++ b/kg-microbe.md
@@ -81,9 +81,6 @@ The kg-microbe knowledge graph serves as the foundation for numerous CultureBotA
 - **[PFAS-AI](/resources/#pfas-ai-machine-learning-enabled-pfas-biodegradation-pipeline)** & PFASCommunityAgents - PFAS biodegradation research *(PFASCommunityAgents is private, public release planned)*
 - **CMM-AI** - Lanthanide bioprocessing research leveraging metabolic data *(private repo, public release planned)*
 
-### Web Services
-- **[MicroGrowLinkService](/resources/#microgrowlinkservice)** - RESTful API providing programmatic access to predictions
-
 [Explore all projects and their relationships →](/resources/#project-ecosystem--workflows)
 
 ## Access and Usage
@@ -128,7 +125,6 @@ KG-Microbe is the training substrate for several prediction approaches, spanning
 - **[Explainable rule mining](https://doi.org/10.1016/j.csbj.2025.10.014)** — human-readable association rules predicting cultivation media from microbial traits, (*CSBJ* 2025). The [RuleML/GOBLIN lecture](https://youtu.be/p_WiR-5E9x0) reports accuracy comparable to state-of-the-art and gives an example of a learned rule: *if β-galactosidase activity and isolated from a marine environment, then 87% likely to grow on Marine Broth*
 - **[KOGUT](/resources/#kogut-transformer)** — relational graph transformer trained on the merged graph (1,379,337 nodes, 2,960,472 edges, 24 Biolink relation types) for growth media link prediction
 - **[MicroGrowAgents](/microgrowagents/)** — multi-agent system that reasons over the graph alongside literature and genome evidence
-- **[MicroGrowLink](/resources/#microgrowlink)** — graph and transformer models for media link prediction
 
 ## Related Resources
 

--- a/kg-microbe.md
+++ b/kg-microbe.md
@@ -152,7 +152,7 @@ KG-Microbe is a comprehensive, modular knowledge graph for microbiology and micr
 KG-Microbe was developed by Dr. Marcin P. Joachimiak and collaborators including Brook E. Santangelo, Harshad Hegde, J. Harry Caufield, Justin Reese, Tomas Kliegr, Lawrence E. Hunter, Catherine A. Lozupone, and Christopher J. Mungall at Lawrence Berkeley National Laboratory.
 
 ### What is KG-Microbe used for?
-KG-Microbe is used for growth preference prediction, culture optimization, comparative microbiology analysis, ecological modeling, and training AI/ML models for microbial cultivation research.
+KG-Microbe is used for growth preference prediction, culture optimization, comparative microbiology analysis, ecological modeling, and training AI/ML models for many aspects of microbiology, including cultivation.
 
 ### How can I access KG-Microbe?
 KG-Microbe is freely available on GitHub at https://github.com/Knowledge-Graph-Hub/kg-microbe under the BSD-3-Clause license. Comprehensive documentation and examples are included in the repository.

--- a/resources.md
+++ b/resources.md
@@ -11,7 +11,7 @@ CultureBotAI led by Dr. Marcin P. Joachimiak develops and maintains various comp
 
 ## Quick Navigation
 
-**New to CultureBotAI?** Start with [Project Ecosystem & Workflows](#project-ecosystem--workflows) to understand how tools work together.
+**New to CultureBotAI?** Start with [Project Ecosystem & Workflows](#-project-ecosystem--workflows) to understand how tools work together.
 
 **Looking for specific tools?**
 - [AI Curation Tools](#-ai-curation-tools) - The X-Mech suite: CultureMech, MediaIngredientMech, CommunityMech, TraitMech, ProteinTraitsMech, AntibioticMech, CellStructureMech, HabitatMech


### PR DESCRIPTION
Removes from the kg-microbe page the entries a reader cannot follow, and fixes a broken link left beside one of them.

**Removed from kg-microbe.md**
- **MATE-LLM** and **eggnog_runner / eggnogtable** from Projects Built on KG-Microbe: unlinked, annotated as private with a public release planned.
- The **Web Services** section, whose only entry was the MicroGrowLinkService REST API. The heading goes with it.
- **MicroGrowLink**, all three mentions: the models list, and the Prediction & Analysis Tools entry the review caught, which would have left the page advertising the tool in one list while denying it in another.

**Reworded**: the FAQ answer now says the graph is used for training AI/ML models for many aspects of microbiology, including cultivation, rather than for cultivation research alone.

**Fixed**: `/resources/#project-ecosystem--workflows` pointed at nothing. That heading begins with an emoji, so its real id carries a leading hyphen, per the gotcha in this repo's CLAUDE.md. Verified against the deployed HTML rather than a local kramdown. The same broken form appeared in index.md and resources.md and is fixed in all three.

**Left, and filed rather than decided**: two entries of the same kind remain on the page, PFASCommunityAgents and CMM-AI (#45), and the removed tools are still documented across resources.md, research.md, microgrowagents.md and culturemech.md (#46).

Review confirmed no dangling anchors into the removed content, no JSON-LD divergence (the structured-data FAQ has no counterpart to the reworded answer), and no orphaned headings or empty lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PS6azGtXoKybazqDe8Bxmo